### PR TITLE
changing the way kivy is being downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ virtual machines (VMDK or QCOW2 files) to Oracle Cloud Infrastructure.
 
 * [Python](https://www.python.org/)
 * [Kivy](https://kivy.org/)
-* [Oracle](https://github.com/oracle/oci-python-sdk)
+* [Oracle](https://cloud.oracle.com/cloud-infrastructure)
 
 ## Prerequisite
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ virtual machines (VMDK or QCOW2 files) to Oracle Cloud Infrastructure.
 
 * [Python](https://www.python.org/)
 * [Kivy](https://kivy.org/)
-* [Oracle]()
+* [Oracle](https://github.com/oracle/oci-python-sdk)
 
 ## Prerequisite
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ You will need the following things properly installed on your computer:
 
 
 For Ubuntu 
-As well as python-pygame && python-kivy && python-dev tools && libgl1-mesa-dev
 
+https://kivy.org/docs/installation/installation-linux.html
 https://stackoverflow.com/questions/21530577/fatal-error-python-h-no-such-file-or-directory
+
+You might also need libgl1-mesa-dev
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/kivy/kivy.git@master
-Cython==0.26.1
 oci==1.3.14
+Cython==0.26.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+git+https://github.com/kivy/kivy.git@master
 Cython==0.26.1
 oci==1.3.14
-git+https://github.com/kivy/kivy.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Cython==0.26.1
-kivy==1.10.0
 oci==1.3.14
-Pygame==1.9.3
+git+https://github.com/kivy/kivy.git@master


### PR DESCRIPTION
PyPi on Ubuntu does not work and gives problems. Updated reqs to point to master and build from there.